### PR TITLE
remove --filesystem=xdg-config/kdeglobals:ro

### DIFF
--- a/org.leocad.LeoCAD.json
+++ b/org.leocad.LeoCAD.json
@@ -11,8 +11,7 @@
         "--device=dri",
         "--share=ipc",
         "--socket=x11",
-        "--filesystem=home",
-        "--filesystem=xdg-config/kdeglobals:ro"
+        "--filesystem=home"
     ],
     "modules": [
         {


### PR DESCRIPTION
not needed since KDE runtime 5.12